### PR TITLE
14: Removing # in the PR format.

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -15,12 +15,12 @@ jobs:
             const prTitle = context.payload.pull_request.title;
             const prBody = context.payload.pull_request.body;
 
-            const titleRegex = /^#(\d+): .+/;
+            const titleRegex = /^(\d+): .+/;
             const titleMatch = prTitle.match(titleRegex);
 
             // Check PR Title Format
             if (!titleMatch) {
-              throw new Error('❌ The PR title does not match the required format `#XXX: Description`.');
+              throw new Error('❌ The PR title does not match the required format `ISSUE_NUMBER: Description`.');
             }
             console.log('✅ PR title format is correct.');
 
@@ -29,7 +29,7 @@ jobs:
             const bodyMatch = prBody.match(bodyRegex);
 
             if (!bodyMatch) {
-              throw new Error('❌ The PR description does not contain `Closes #XXX` with an issue number.');
+              throw new Error('❌ The PR description does not contain `Closes ISSUE_NUMBER` with an issue number.');
             }
             console.log('✅ PR description contains issue reference.');
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ is complete, a pull request onto main is opened for review. The title of the PR
 must read as:
 
 ```
-#ISSUE-NUMBER: Description of PR.
+ISSUE-NUMBER: Description of PR.
 ```
 
 Where the issue number must link to a valid issue. PRs require at least one review 


### PR DESCRIPTION
## Issue

Closes #14 

## Description

The previous PR title convention caused issues because the # was considered as a comment starting character.

## Verification

Docs are updated and the tests passed so the new format has been confirmed. Here is a screenshot showing the new test results

![image](https://github.com/user-attachments/assets/fc768a67-fadb-40b4-8804-be7ffceb0725)

