### PR TITLE
23: Unique save location for feed_me

### DIFF
--- a/feed_me/src/feed_me/__init__.py
+++ b/feed_me/src/feed_me/__init__.py
@@ -12,4 +12,4 @@ MAX_COST = 1e3
 SMALL_DT = timedelta(seconds=0.1)
 
 # The location to save the task master to.
-TASK_MASTER_PATH = Path("./data/")
+TASK_MASTER_PATH = Path.home() / ".feed_me"

--- a/feed_me/tests/test_cli.py
+++ b/feed_me/tests/test_cli.py
@@ -1,5 +1,18 @@
+# ruff: noqa: E402
+# Disable E402 to allow the sequential importing operation
+# for this test.
 from datetime import datetime, timedelta
+from pathlib import Path
 from click.testing import CliRunner
+
+# Reset the task master path to be local.
+# Must be done before importing the CLI
+# to make the path apply when main is imported.
+import feed_me
+
+feed_me.TASK_MASTER_PATH = Path(".")
+
+# Import the CLI.
 from feed_me.cli import main
 
 

--- a/feed_me/tests/test_cli.py
+++ b/feed_me/tests/test_cli.py
@@ -5,15 +5,16 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from click.testing import CliRunner
 
+# fmt: off
 # Reset the task master path to be local.
 # Must be done before importing the CLI
 # to make the path apply when main is imported.
 import feed_me
-
 feed_me.TASK_MASTER_PATH = Path(".")
 
 # Import the CLI.
 from feed_me.cli import main
+# fmt: on
 
 
 def test_cli_main():


### PR DESCRIPTION
## Issue

Closes #23 
Closes #30 

## Description

Feed me now saves the task_manager in the users home directory `~/.feed_me`. Due to how the feed_me save path is saved, it's kind of a mess in testing but I had to temporarily mutate it. Considering having a feed_me config file that can be mutated and resaved.

## Verification

Tests are still passing.
![image](https://github.com/user-attachments/assets/5276c115-74dc-4bd5-8c32-2b6ec4e12d8b)

And here is the new save location
![image](https://github.com/user-attachments/assets/6fc28a5a-e4e7-4b28-b68d-6982b1b52002)
